### PR TITLE
Remove unnecessary constant and default argument

### DIFF
--- a/lib/tools/io/staticNodeJS.js
+++ b/lib/tools/io/staticNodeJS.js
@@ -10,17 +10,16 @@ define([
   , obtain
 ) {
     "use strict";
-    
+
     if(typeof require.nodeRequire !== 'function')
         return;
-    
+
     var IOError = errors.IO
       , IONoEntry = errors.IONoEntry
        // this is node js
       , fs = require.nodeRequire('fs')
-      ,  _0666 = parseInt('0666', 8)
       ;
-    
+
     var _callbackAdapterFactory = function(callback) {
         return function(error, result) {
             if(error && error.code === 'ENOENT')
@@ -30,7 +29,7 @@ define([
             callback(error, result);
         }
     }
-    
+
     var readFile = obtain.factory(
         {
             readFile:['path', function(path) {
@@ -53,7 +52,7 @@ define([
       , ['path']
       , function(obtain){ return obtain('readFile'); }
     );
-    
+
     var writeFile = obtain.factory(
         {
             writeFile:['path', 'data', function(path, data) {
@@ -77,7 +76,7 @@ define([
       , ['path', 'data']
       , function(obtain){ return obtain('writeFile'); }
     );
-    
+
     var unlink = obtain.factory(
         {
             unlink:['filename', function(filename) {
@@ -100,7 +99,7 @@ define([
       , ['filename']
       , function(obtain){ return obtain('unlink'); }
     );
-    
+
     var readBytes = obtain.factory(
         {
             readBytes:['path', 'bytes', function(path, bytes) {
@@ -116,7 +115,7 @@ define([
                         throw new IONoEntry(error.message, error.stack);
                     throw error;
                 }
-                
+
                 fs.readSync(file, buffer, 0, bytes, 0);
                 fs.closeSync(file);
                 return buffer.toString('binary', 0, bytes);
@@ -126,7 +125,7 @@ define([
             readBytes:['path', 'bytes', '_callback',
             function(path, bytes, callback) {
                 callback = _callbackAdapterFactory(callback)
-                
+
                 var onFile = function(err, fd) {
                     if(err) {
                         callback(err);
@@ -142,13 +141,13 @@ define([
                     }
                     callback(undefined, buffer.toString('binary', 0, bytes));
                 }
-                fs.open(path, 'r', _0666, onFile);
+                fs.open(path, 'r', onFile);
             }]
         }
       , ['path', 'bytes']
       , function(obtain){ return obtain('readBytes'); }
     );
-    
+
     var pathExists = obtain.factory(
         {
             pathExists:['path', function(path) {
@@ -164,7 +163,7 @@ define([
       , ['path']
       , function(obtain){ return obtain('pathExists'); }
     );
-    
+
     var getMtime = obtain.factory(
         {
             getMtime:['path', function(path) {
@@ -193,7 +192,7 @@ define([
       , ['path']
       , function(obtain){ return obtain('getMtime'); }
     );
-    
+
     /**
      * raises IOError if dir can't be created
      */
@@ -225,7 +224,7 @@ define([
       , ['path']
       , function(obtain){ return obtain('mkDir'); }
     );
-    
+
     /**
      * raises IOError if dir can't be deleted
      */
@@ -257,7 +256,7 @@ define([
       , ['path']
       , function(obtain){ return obtain('rmDir'); }
     );
-    
+
     return {
         readFile: readFile
       , writeFile: writeFile


### PR DESCRIPTION
0666 is  the default mode for reading, and the argument does not need to be supplied. See http://nodejs.org/api/fs.html#fs_fs_open_path_flags_mode_callback
