### PR TITLE
Allow a callback to record glyphs which load badly. The default is to

### DIFF
--- a/lib/ufoLib/glifLib/GlyphSet.js
+++ b/lib/ufoLib/glifLib/GlyphSet.js
@@ -137,7 +137,8 @@ define(
         io,
         dirName,
         glyphNameToFileNameFunc /* undefined */,
-        ufoFormatVersion /* 3 */
+        ufoFormatVersion /* 3 */,
+        readErrorCallback
     ) {
         if(io === undefined)
             throw new GlifLibError('GlyphSet I/O module missing');
@@ -168,6 +169,7 @@ define(
         // this.rebuildContents();
     }
 
+
     GlyphSet.factory = obtain.factory(
         {
             instance: ['io', 'dirName', 'glyphNameToFileNameFunc', 'ufoFormatVersion',
@@ -195,6 +197,10 @@ define(
 
     _p._writeFile = _writeFile;
     _p._unlink = _unlink;
+
+    _p.setReadErrorCallback = function( cb ) {
+        this.readErrorCallback = cb;
+    }
 
     /**
      * Rebuild the contents dict by loading contents.plist.
@@ -688,7 +694,8 @@ define(
             formatVersions = this.ufoFormatVersion < 3
                     ? [1]
                     : [1, 2];
-            readGlyph.fromDOM(glifDoc, glyphObject, pointPen, formatVersions)
+
+            readGlyph.fromDOM(glifDoc, glyphObject, pointPen, formatVersions, this.readErrorCallback )
             return glyphObject;
         }
     )

--- a/lib/ufoLib/glifLib/readGlyph.js
+++ b/lib/ufoLib/glifLib/readGlyph.js
@@ -71,10 +71,11 @@ define([
         glyphObject /* undefined */,
         pointPen /* undefined */,
         // the formatVersions argument is not used! this was in the python code.
-        formatVersions /* default = [1, 2]*/
+        formatVersions /* default = [1, 2]*/,
+        errorCallback
     ) {
         var glifDoc = xml.parseXMLString(glyphDataString);
-        readGlyphFromDOM(glifDoc, glyphObject, pointPen, formatVersions);
+        readGlyphFromDOM(glifDoc, glyphObject, pointPen, formatVersions, errorCallback );
     }
     
     /**
@@ -85,7 +86,8 @@ define([
         glyphObject /* undefined */,
         pointPen /* undefined */,
         // the formatVersions argument is not used! this was in the python code.
-        formatVersions /* default = [1, 2]*/
+        formatVersions /* default = [1, 2]*/,
+        errorCallback
     ) {
         // quick format validation
         var root = glifDoc.documentElement,
@@ -97,16 +99,23 @@ define([
             formatError = true;
         if(formatError)
             throw new GlifLibError('GLIF data is not properly formatted.');
+
+        // if they don't override we will throw an error
+        if( errorCallback === undefined ) {
+            errorCallback = function( glyphName, message ) {
+                throw new GlifLibError( message ); 
+            };
+        }
+
         // check the format version
-        
         formatVersion = root.getAttribute('format');
         formatVersion = main.isIntString(formatVersion)
             ? parseInt(formatVersion, 10)
             : formatVersion;
         if(formatVersion === 1)
-            _readGlyphFromTreeFormat1(glifDoc, glyphObject, pointPen);
+            _readGlyphFromTreeFormat1(glifDoc, glyphObject, pointPen, errorCallback);
         else if(formatVersion === 2)
-            _readGlyphFromTreeFormat2(glifDoc, glyphObject, pointPen);
+            _readGlyphFromTreeFormat2(glifDoc, glyphObject, pointPen, errorCallback);
         else
             throw new GlifLibError('Unsupported GLIF format version: '
                 + formatVersion + '.');
@@ -232,12 +241,17 @@ define([
     function _readGlyphFromTreeFormat1(
         glifDoc,
         glyphObject/* undefined */,
-        pointPen/* undefined */
+        pointPen/* undefined */,
+        errorCallbackFull
     ) {
         var root = glifDoc.documentElement;
         // get the name
         _relaxedSetattr( glyphObject, 'name', _readName(root));
-        
+
+        // bind the glyph name so that lower methods don't need it
+        var errorCallbackGlyph = { name: glyphObject['name'] };
+        var errorCallback = errorCallbackFull.bind(null, errorCallbackGlyph );
+
         // populate the sub elements
         var unicodes = {list: [], dict: {}},
             haveSeenAdvance = false,
@@ -260,7 +274,8 @@ define([
                 haveSeenOutline = true;
                 if(pointPen !== undefined)
                     buildOutlineFormat1(glyphObject, pointPen,
-                        _listOfChildren(node));
+                                        _listOfChildren(node),
+                                        errorCallback );
             }
             else if(element === 'advance') {
                 if(haveSeenAdvance)
@@ -309,11 +324,15 @@ define([
     function _readGlyphFromTreeFormat2(
         glifDoc,
         glyphObject/* undefined */,
-        pointPen/* undefined */
+        pointPen/* undefined */,
+        errorCallbackFull
     ) {
         var root = glifDoc.documentElement;
         // get the name
         _relaxedSetattr(glyphObject, 'name', _readName(root));
+        var errorCallbackGlyph = { name: glyphObject['name'] };
+        var errorCallback = errorCallbackFull.bind(null, errorCallbackGlyph );
+
         // populate the sub elements
         var unicodes = {list: [], dict: {}},
             guidelines = [],
@@ -356,8 +375,9 @@ define([
                     // That is a bad thing.
                     // I'm leaving it for now, because the first aim is
                     // to be compatible to robofab.
-                    buildOutlineFormat2(pointPen, _listOfChildren(node),
-                        identifiers);
+                    buildOutlineFormat2( pointPen, _listOfChildren(node),
+                                         identifiers,
+                                         errorCallback );
             }
             else if(element === 'advance') {
                 if(haveSeenAdvance)
@@ -542,7 +562,7 @@ define([
     
     // format 1
     
-    function buildOutlineFormat1(glyphObject, pen, nodes) {
+    function buildOutlineFormat1(glyphObject, pen, nodes, errorCallback ) {
         var i = 0,
             anchors = [],
             node, child, anchor;
@@ -570,7 +590,7 @@ define([
                     //         + 'element: ' + child.tagName);
                 }
                 else
-                    _buildOutlineContourFormat1(pen, node)
+                    _buildOutlineContourFormat1(pen, node, errorCallback)
             }
             else if(node.tagName == 'component')
                 _buildOutlineComponentFormat1(pen, node);
@@ -605,7 +625,7 @@ define([
         }
     }
     
-    function _buildOutlineContourFormat1(pen, contour) {
+    function _buildOutlineContourFormat1(pen, contour,errorCallback) {
         var children
         if (contour.attributes.length)
             throw new GlifLibError('Unknown attributes in contour element.')
@@ -614,7 +634,8 @@ define([
             children = _validateAndMassagePointStructures(
                 _listOfChildren(contour),
                 pointAttributesFormat1,
-                /* openContourOffCurveLeniency */ true)
+                /* openContourOffCurveLeniency */ true,
+                errorCallback )
             _buildOutlinePointsFormat1(pen, children)
         }
         pen.endPath();
@@ -674,7 +695,7 @@ define([
             identifiers[identifier] = true;
     }
     
-    function buildOutlineFormat2(pen, nodes, identifiers) {
+    function buildOutlineFormat2(pen, nodes, identifiers, errorCallback ) {
         var anchors = [], node, i=0;
         for (; i<nodes.length; i++) {
             node = nodes[i];
@@ -683,16 +704,16 @@ define([
                     + 'properly structured.');
             
             if(node.tagName === 'contour')
-                _buildOutlineContourFormat2(pen, node, identifiers)
+                _buildOutlineContourFormat2(pen, node, identifiers, errorCallback )
             else if(node.tagName == 'component')
-                _buildOutlineComponentFormat2(pen, node, identifiers)
+                _buildOutlineComponentFormat2(pen, node, identifiers, errorCallback )
             else
                 throw new GlifLibError('Unknown element in outline '
                     + 'element: ' + node.tagName);
         }
     }
     
-    function _buildOutlineContourFormat2(pen, contour, identifiers) {
+    function _buildOutlineContourFormat2(pen, contour, identifiers, errorCallback) {
         var identifier, children;
         
         // throws GlifLibError
@@ -721,7 +742,9 @@ define([
         if (contour.children.length) {
             children = _validateAndMassagePointStructures(
                 _listOfChildren(contour),
-                pointAttributesFormat2
+                pointAttributesFormat2,
+                false,
+                errorCallback
             );
             _buildOutlinePointsFormat2(pen, children, identifiers);
         }
@@ -769,7 +792,7 @@ define([
         }
     }
     
-    function _buildOutlineComponentFormat2(pen, component, identifiers) {
+    function _buildOutlineComponentFormat2(pen, component, identifiers, errorCallback ) {
         var baseGlyphName, transformation, identifier;
         
         if (component.children.length)
@@ -816,7 +839,8 @@ define([
     function _validateAndMassagePointStructures(
         children /* a list of DOM Elements */,
         pointAttributes /* a setlike Objekt */,
-        openContourOffCurveLeniency /* default: False */
+        openContourOffCurveLeniency /* default: False */,
+        errorCallback
     ) {
         // store some data for later validation
         var pointTypes = [],
@@ -931,12 +955,21 @@ define([
                         throw new GlifLibError('move can not have an '
                             + 'offcurve.');
                     else if(segmentType === 'line')
-                        throw new GlifLibError('line can not have an '
-                            + 'offcurve.');
+                        {
+                            errorCallback( 'line can not have an offcurve.');
+
+                            // still here, try to recover.
+                            resultChildren = [];
+                            return resultChildren;
+                        }
                     else if(segmentType === 'curve')
-                        if (offCurves.length > 2)
-                            throw new GlifLibError('Too many offcurves '
-                                + 'defined for curve.');
+                        if (offCurves.length > 2) {
+                            errorCallback( 'Too many offcurves defined for curve.');
+
+                            // still here, try to recover.
+                            resultChildren = [];
+                            return resultChildren;
+                        }
                 //    else if(segmentType === "qcurve")
                 //        {/* pass */}
                 //    else


### PR DESCRIPTION
throw an exception in such cases which should preserve the previous
behavior.

For importing glyphs metapolator can set a different callback and
allow the load to proceed beyond the failing glyph.

This is for metapolator issue https://github.com/metapolator/metapolator/issues/144
