### PR TITLE
issue144: using winston to keep the code impact more local.

### DIFF
--- a/lib/ufoLib/glifLib/GlyphSet.js
+++ b/lib/ufoLib/glifLib/GlyphSet.js
@@ -54,7 +54,6 @@ define(
       , './readGlyph'
       , './writeGlyph'
       , './rapidValueFetching'
-
     ],
     function(
         main

--- a/lib/ufoLib/glifLib/misc.js
+++ b/lib/ufoLib/glifLib/misc.js
@@ -12,13 +12,15 @@ define(
     'ufojs/main',
     'ufojs/errors',
     'ufojs/ufoLib/filenames',
-    'ufojs/ufoLib/validators'
+    'ufojs/ufoLib/validators',
+    'winston'
     ],
     function(
         main,
         errors,
         filenames,
-        validators
+        validators,
+        winston
 ) {
     "use strict";
     var setLike = main.setLike,
@@ -103,11 +105,32 @@ define(
         }
         return validInfoData;
     }
+
+    /**
+     * The default winston logger does no logging, but for errors the
+     * original exception is rethrown. Doing this preserves the stack
+     * backtrace from the original call point.
+     */
+    function _makeRethrowLogger() {
+        var x = new (winston.Logger)({
+            transports: [
+                new (winston.transports.Console)()
+            ]
+        });
+        x.on('logging', function (transport, level, msg, meta) {
+            console.log("ufojs/misc/logger level:" + level + " msg:" + msg );
+            if( level == 'error' ) {
+                throw meta.err;
+            }
+        });
+        return x;
+    }
     
     return {
         glyphNameToFileName : glyphNameToFileName,
         layerInfoVersion3ValueData: layerInfoVersion3ValueData,
         validateLayerInfoVersion3ValueForAttribute : validateLayerInfoVersion3ValueForAttribute,
-        validateLayerInfoVersion3Data : validateLayerInfoVersion3Data
+        validateLayerInfoVersion3Data : validateLayerInfoVersion3Data,
+        logger: _makeRethrowLogger()
     }
 });

--- a/lib/ufoLib/glifLib/readGlyph.js
+++ b/lib/ufoLib/glifLib/readGlyph.js
@@ -17,6 +17,7 @@ define([
   , 'ufojs/plistLib/main'
   , 'ufojs/ufoLib/validators'
   , './constants'
+  , './misc'
 ], function(
     main
   , errors
@@ -24,6 +25,7 @@ define([
   , plistLib
   , validators
   , constants
+  , misc
 ) {
     "use strict";
     var GlifLibError = errors.GlifLib,
@@ -98,7 +100,7 @@ define([
         if(formatError)
             throw new GlifLibError('GLIF data is not properly formatted.');
         // check the format version
-        
+
         formatVersion = root.getAttribute('format');
         formatVersion = main.isIntString(formatVersion)
             ? parseInt(formatVersion, 10)
@@ -237,7 +239,10 @@ define([
         var root = glifDoc.documentElement;
         // get the name
         _relaxedSetattr( glyphObject, 'name', _readName(root));
-        
+
+        // bind the glyph name so that lower methods don't need it
+        misc.logger.glyphName = glyphObject['name'];
+
         // populate the sub elements
         var unicodes = {list: [], dict: {}},
             haveSeenAdvance = false,
@@ -303,6 +308,9 @@ define([
         // set the collected unicodes
         if(unicodes.list.length)
             _relaxedSetattr(glyphObject, 'unicodes', unicodes.list);
+
+        misc.logger.glyphName = "";
+
     }
     
     
@@ -314,6 +322,10 @@ define([
         var root = glifDoc.documentElement;
         // get the name
         _relaxedSetattr(glyphObject, 'name', _readName(root));
+
+        // bind the glyph name so that lower methods don't need it
+        misc.logger.glyphName = glyphObject['name'];
+
         // populate the sub elements
         var unicodes = {list: [], dict: {}},
             guidelines = [],
@@ -810,8 +822,14 @@ define([
                 + 'has been discarded.');
         }
     }
-    
+
+
     // all formats
+
+    function _notifyReadError( err ) {
+        misc.logger.error( err.message, { glyphName: misc.logger.glyphName, err: err } );
+    }
+
     
     function _validateAndMassagePointStructures(
         children /* a list of DOM Elements */,
@@ -931,12 +949,21 @@ define([
                         throw new GlifLibError('move can not have an '
                             + 'offcurve.');
                     else if(segmentType === 'line')
-                        throw new GlifLibError('line can not have an '
-                            + 'offcurve.');
+                        {
+                            _notifyReadError(new GlifLibError('line can not have an offcurve.'));
+
+                            // still here, try to recover.
+                            resultChildren = [];
+                            return resultChildren;
+                        }
                     else if(segmentType === 'curve')
-                        if (offCurves.length > 2)
-                            throw new GlifLibError('Too many offcurves '
-                                + 'defined for curve.');
+                        if (offCurves.length > 2) {
+                            _notifyReadError(new GlifLibError('Too many offcurves defined for curve.'));
+
+                            // still here, try to recover.
+                            resultChildren = [];
+                            return resultChildren;
+                        }
                 //    else if(segmentType === "qcurve")
                 //        {/* pass */}
                 //    else


### PR DESCRIPTION
The ufoJS code now uses a misc.logger to tell when bad things happen during the load. This removes the passing of callbacks down the function chain.

The default ufoJS is to rethrow the exception case that was passed to logger. This should give the same behaviour as before the PR. Notice that in makeRethrowLogger() he original meta.err is thrown, so the stack trace should look as one would expect.

Code like MP can patch the misc.logger to their own logger (which I have a separate PR todo) and thus record failures and allow the program to continue loading.

If this looks like a solution that might be merged then I'll do more testing on it than the few runs so far. 
This replaces https://github.com/graphicore/ufoJS/pull/12.

One downside to the current code is that the logger is ufoJS wide. It would be nice to be able to patch the logger on a GlyphSet basis and leave other GlyphSets using the unpatched logger instance.
