### PR TITLE
Add recursive directory (& contents) removal to io

### DIFF
--- a/lib/tools/io/_base.js
+++ b/lib/tools/io/_base.js
@@ -4,7 +4,7 @@
  * It makes heavy use of obtainJS.
  * 
  * You can and should use this module as prototype for your implementation
- * (if there is ingeritance). We might use that as a base for unit-testing,
+ * (if there is inheritance). We might use that as a base for unit-testing,
  * however ufoJS will use ducktyping and just expect your implementation
  * to work.
  * 
@@ -25,11 +25,19 @@ define([
     "use strict";
     
     var NotImplementedError = errors.NotImplemented
-    
+      , Parent = Object
+      ;
+
+    function io() {
+        Parent.call(this);
+    };
+
+    var _p = io.prototype = Object.create(Parent.prototype);
+
     /**
      * raises IONoEntry when path is not found.
      */
-    var readFile = obtain.factory(
+    _p.readFile = obtain.factory(
         {
             readFile:['path', function(path) {
                 throw new NotImplementedError('readFile');
@@ -43,7 +51,7 @@ define([
     /**
      * raises IONoEntry when path is in an non-existant directory
      */
-    var writeFile = obtain.factory(
+    _p.writeFile = obtain.factory(
         {
             writeFile:['path', 'data', function(path, data) {
                 throw new NotImplementedError('writeFile');
@@ -57,7 +65,7 @@ define([
     /**
      * raises IONoEntry when path is not found.
      */
-    var unlink = obtain.factory(
+    _p.unlink = obtain.factory(
         {
             unlink:['filename', function(filename) {
                 throw new NotImplementedError('unlink');
@@ -68,7 +76,7 @@ define([
       , function(obtain){ return obtain('unlink'); }
     );
     
-    var readBytes = obtain.factory(
+    _p.readBytes = obtain.factory(
         {
             readBytes:['path', 'bytes', function(path, bytes) {
                 throw new NotImplementedError('readBytes');
@@ -79,7 +87,21 @@ define([
       , function(obtain){ return obtain('readBytes'); }
     );
     
-    var pathExists = obtain.factory(
+    /**
+     * raises IONoEntry when path is not found.
+     */
+    _p.stat = obtain.factory(
+        {
+            stat:['path', function(path) {
+                throw new NotImplementedError('stat');
+            }]
+        }
+      , {/* no need for async here */}
+      , ['path']
+      , function(obtain){ return obtain('stat'); }
+    );
+
+    _p.pathExists = obtain.factory(
         {
             pathExists:['path', function(path) {
                 throw new NotImplementedError('pathExists');
@@ -93,7 +115,7 @@ define([
     /**
      * raises IONoEntry when path is not found.
      */
-    var getMtime = obtain.factory(
+    _p.getMtime = obtain.factory(
         {
             getMtime:['path', function(path) {
                 throw new NotImplementedError('getMtime');
@@ -107,7 +129,21 @@ define([
     /**
      * raises IOError if dir can't be created
      */
-    var mkDir = obtain.factory(
+    _p.readDir = obtain.factory(
+        {
+            readDir:['path', function(path) {
+                throw new NotImplementedError('readDir');
+            }]
+        }
+      , {/* no need for async here */}
+      , ['path']
+      , function(obtain){ return obtain('readDir'); }
+    );
+
+    /**
+     * raises IOError if dir can't be created
+     */
+    _p.mkDir = obtain.factory(
         {
             mkDir:['path', function(path) {
                 throw new NotImplementedError('mkDir');
@@ -121,7 +157,7 @@ define([
     /**
      * raises IOError if dir can't be deleted
      */
-    var rmDir = obtain.factory(
+    _p.rmDir = obtain.factory(
         {
             rmDir:['path', function(path) {
                 throw new NotImplementedError('rmDir');
@@ -131,16 +167,27 @@ define([
       , ['path']
       , function(obtain){ return obtain('rmDir'); }
     );
-    
-    
-    return {
-        readFile: readFile
-      , writeFile: writeFile
-      , unlink: unlink
-      , readBytes: readBytes
-      , pathExists: pathExists
-      , getMtime: getMtime
-      , mkDir: mkDir
-      , rmDir: rmDir
-    };
+
+    /**
+     * Implemented in terms of other io methods
+     */
+    _p.rmDirRecursive = obtain.factory(
+        {
+            rmDirRecursive:['dir', function(dir) {
+                var objs = this.readDir(false, dir);
+                for(var i = 0; i < objs.length; i++) {
+                    var obj = dir + '/' + objs[i]; // path.join is node-specific
+                    (this.stat(false, obj).isDirectory() ? this.rmDirRecursive : this.unlink)(false, obj);
+                }
+                this.rmDir(false, dir);
+            }]
+        }
+      // For an async implementation, try starting here:
+      // https://gist.github.com/yoavniran/adbbe12ddf7978e070c0
+      , {/* no need for async here */}
+      , ['dir']
+      , function(obtain){ return obtain('rmDirRecursive'); }
+    );
+
+    return io;
 });

--- a/lib/tools/io/staticBrowserREST.js
+++ b/lib/tools/io/staticBrowserREST.js
@@ -1,22 +1,29 @@
 /**
- * This is a simple NodeJS implementation for io/_base.
+ * This is a NodeJS implementation of io/_base.
  */
 define([
     'ufojs/errors'
   , 'obtain/obtain'
-
+  , './_base'
 ], function(
     errors
   , obtain
+  , Parent
 ) {
     "use strict";
     
     if(typeof require.nodeRequire === 'function')
-        return;
+        return null;
     
     var IOError = errors.IO
       , IONoEntry = errors.IONoEntry
       ;
+
+    function Io() {
+        Parent.call(this);
+    }
+
+    var _p = Io.prototype = Object.create(Parent.prototype);
 
     var _errorFromRequest = function(request) {
         var message = ['Status', request.status, request.statusText].join(' ')
@@ -30,7 +37,7 @@ define([
         return path.split('/').map(encodeURIComponent).join('/')
     }
     
-    var readFile = obtain.factory(
+    _p.readFile = obtain.factory(
         {
             uri: ['path', _path2uri]
           , readFile:['uri', function(path) {
@@ -69,7 +76,7 @@ define([
       , function(obtain){ return obtain('readFile'); }
     );
     
-    var writeFile = obtain.factory(
+    _p.writeFile = obtain.factory(
         {
             uri: ['path', _path2uri]
           , writeFile:['uri', 'data', function(path, data) {
@@ -103,7 +110,7 @@ define([
       , function(obtain){ return obtain('writeFile'); }
     );
     
-    var unlink = obtain.factory(
+    _p.unlink = obtain.factory(
         {
             uri: ['filename', _path2uri]
           , unlink:['uri', function(filename) {
@@ -136,7 +143,7 @@ define([
       , function(obtain){ return obtain('unlink'); }
     );
     
-    var readBytes = obtain.factory(
+    _p.readBytes = obtain.factory(
         {
             uri: ['path', _path2uri]
           , readBytes:['uri', 'bytes', function(path, bytes) {
@@ -190,10 +197,10 @@ define([
     // which should work for files and directories regardless,
     // but to work for directories it shoud attach a slash (so the REST
     // server) can easily know what is meant
-    // POPOSED FIX: the io api needs a split into: dirExists and fileExists
+    // PROPOSED FIX: the io api needs a split into: dirExists and fileExists
     // so we could create a clear distinction and append the indicating
     // slash. path exists would be removed
-    var pathExists = obtain.factory(
+    _p.pathExists = obtain.factory(
         {
             uri: ['path', _path2uri]
           , pathExists:['uri', function(path) {
@@ -218,7 +225,7 @@ define([
       , function(obtain){ return obtain('pathExists'); }
     );
     
-    var getMtime = obtain.factory(
+    _p.getMtime = obtain.factory(
         {
             uri: ['path', _path2uri]
           , getMtime:['uri', function(path) {
@@ -254,7 +261,7 @@ define([
       , function(obtain){ return obtain('getMtime'); }
     );
     
-    var mkDir = obtain.factory({
+    _p.mkDir = obtain.factory({
             uri: ['path', _path2uri]
           , dirName: ['uri', function(uri) {
                 // the endpoint will only create a directory if uri ends width
@@ -294,10 +301,10 @@ define([
       , function(obtain){ return obtain('mkDir'); }
     );
     
-    var rmDir = obtain.factory({
+    _p.rmDir = obtain.factory({
             uri: ['path', _path2uri]
           , dirName: ['uri', function(uri) {
-                // the endpoint will only create a directory if uri ends width
+                // the endpoint will only remove a directory if uri ends width
                 // a slash
                 return uri + (uri.slice(-1) !== '/' ? '/' : '');
             }]
@@ -311,7 +318,7 @@ define([
             }]
         }
       , {
-            mkDir:['dirName', '_callback', function(path, callback) {
+            rmDir:['dirName', '_callback', function(path, callback) {
                 var request = new XMLHttpRequest()
                     , result
                     , error
@@ -332,14 +339,5 @@ define([
       , function(obtain){ return obtain('rmDir'); }
     );
     
-    return {
-        readFile: readFile
-      , writeFile: writeFile
-      , unlink: unlink
-      , readBytes: readBytes
-      , pathExists: pathExists
-      , getMtime: getMtime
-      , mkDir: mkDir
-      , rmDir: rmDir
-    };
+    return new Io(); // Single instance of static type
 });

--- a/lib/tools/io/staticNodeJS.js
+++ b/lib/tools/io/staticNodeJS.js
@@ -1,24 +1,31 @@
 /**
- * This is a simple NodeJS implementation for io/_base.
+ * This is a NodeJS implementation of io/_base.
  */
 define([
     'ufojs/errors'
   , 'obtain/obtain'
-
+  , './_base'
 ], function(
     errors
   , obtain
+  , Parent
 ) {
     "use strict";
 
     if(typeof require.nodeRequire !== 'function')
-        return;
+        return null;
 
     var IOError = errors.IO
       , IONoEntry = errors.IONoEntry
        // this is node js
       , fs = require.nodeRequire('fs')
       ;
+
+    function Io() {
+        Parent.call(this);
+    }
+
+    var _p = Io.prototype = Object.create(Parent.prototype);
 
     var _callbackAdapterFactory = function(callback) {
         return function(error, result) {
@@ -30,7 +37,7 @@ define([
         }
     }
 
-    var readFile = obtain.factory(
+    _p.readFile = obtain.factory(
         {
             readFile:['path', function(path) {
                 try {
@@ -53,7 +60,7 @@ define([
       , function(obtain){ return obtain('readFile'); }
     );
 
-    var writeFile = obtain.factory(
+    _p.writeFile = obtain.factory(
         {
             writeFile:['path', 'data', function(path, data) {
                 try {
@@ -77,7 +84,7 @@ define([
       , function(obtain){ return obtain('writeFile'); }
     );
 
-    var unlink = obtain.factory(
+    _p.unlink = obtain.factory(
         {
             unlink:['filename', function(filename) {
                 try {
@@ -100,7 +107,7 @@ define([
       , function(obtain){ return obtain('unlink'); }
     );
 
-    var readBytes = obtain.factory(
+    _p.readBytes = obtain.factory(
         {
             readBytes:['path', 'bytes', function(path, bytes) {
                 var file
@@ -148,11 +155,29 @@ define([
       , function(obtain){ return obtain('readBytes'); }
     );
 
-    var pathExists = obtain.factory(
+    _p.stat = obtain.factory(
         {
-            pathExists:['path', function(path) {
-                return fs.existsSync(path);
+            stat:['path', function(path) {
+                try {
+                    return fs.statSync(path);
+                }
+                catch(error) {
+                    if(error.code === 'ENOENT')
+                        throw new IONoEntry(error.message, error.stack);
+                    throw error;
+                }
             }]
+        }
+      , {
+            stat:['path', '_callback', fs.stat]
+        }
+      , ['path']
+      , function(obtain){ return obtain('stat'); }
+    );
+
+    _p.pathExists = obtain.factory(
+        {
+            pathExists:['path', fs.existsSync]
         }
       , {
             pathExists:['path', '_callback', '_errback',
@@ -164,7 +189,7 @@ define([
       , function(obtain){ return obtain('pathExists'); }
     );
 
-    var getMtime = obtain.factory(
+    _p.getMtime = obtain.factory(
         {
             getMtime:['path', function(path) {
                 try {
@@ -194,9 +219,26 @@ define([
     );
 
     /**
+     * raises IOError if dir can't be deleted
+     */
+    _p.readDir = obtain.factory(
+        {
+            readDir:['path', fs.readdirSync]
+        }
+      , {
+            readDir:['path', '_callback',
+            function(path, callback) {
+                fs.readdir(path, callback);
+            }]
+        }
+      , ['path']
+      , function(obtain){ return obtain('readDir'); }
+    );
+
+    /**
      * raises IOError if dir can't be created
      */
-    var mkDir = obtain.factory(
+    _p.mkDir = obtain.factory(
         {
             mkDir:['path', function(path) {
                 try {
@@ -211,7 +253,7 @@ define([
         }
       , {
             mkDir:['path', '_callback',
-            function(path, data, callback) {
+            function(path, callback) {
                 var callback = _callbackAdapterFactory(callback)
                   , callbackSkipEEXIST = function(err) {
                         if(err && error.code === 'EEXIST')
@@ -228,7 +270,7 @@ define([
     /**
      * raises IOError if dir can't be deleted
      */
-    var rmDir = obtain.factory(
+    _p.rmDir = obtain.factory(
         {
             rmDir:['path', function(path) {
                 try {
@@ -236,14 +278,14 @@ define([
                 }
                 catch(error) {
                     if(error.code !== 'ENOENT')
-                        // skip if dir already deleted
+                        // skip if dir does not exist
                         throw new IOError(error.code + ' ' + error.message, error.stack);
                 }
             }]
         }
       , {
             rmDir:['path', '_callback',
-            function(path, data, callback) {
+            function(path, callback) {
                 var callback = _callbackAdapterFactory(callback)
                   , callbackSkipENOENT = function(err) {
                         if(err && error.code === 'ENOENT')
@@ -257,14 +299,5 @@ define([
       , function(obtain){ return obtain('rmDir'); }
     );
 
-    return {
-        readFile: readFile
-      , writeFile: writeFile
-      , unlink: unlink
-      , readBytes: readBytes
-      , pathExists: pathExists
-      , getMtime: getMtime
-      , mkDir: mkDir
-      , rmDir: rmDir
-    };
+    return new Io(); // Single instance of static type
 });


### PR DESCRIPTION
In order to achieve this, I performed some restructuring:
1. Make the io implementation modules actually inherit from _base, but
   statically (should this be a documented pattern in the coding style wiki
   page?)
2. Implement readDir and stat methods in staticNodeJS module only (it’s
   not obvious to me how to implement them in REST).
3. Implement rmDirRecursive as an abstract method. At the moment it will
   only work in Node, because of the missing methods in REST (see 2 above).
