### PR TITLE
Add ensureDir; make mkDir complain when directory exists

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -51,6 +51,7 @@ define(function() {
     makeError('Parser', undefined , new errors.Error);
     makeError('IO', undefined , new errors.Error);
     makeError('IONoEntry', undefined, new errors.IO)
+    makeError('IOEntryExists', undefined, new errors.IO)
     makeError('NameTranslation', undefined , new errors.Error);
     makeError('GlifLib', undefined , new errors.Error);
     makeError('Key', undefined , new TypeError);

--- a/lib/tools/io/_base.js
+++ b/lib/tools/io/_base.js
@@ -115,6 +115,10 @@ define([
       , function(obtain){ return obtain('stat'); }
     );
 
+    /**
+     * Don't use this method to check whether something exists before doing
+     * an operation on it, that only creates a race condition.
+     */
     _p.pathExists = obtain.factory(
         {
             pathExists:['path', function(path) {
@@ -141,7 +145,7 @@ define([
     );
     
     /**
-     * raises IOError if dir can't be created
+     * raises IOError if dir doesn't exist
      */
     _p.readDir = obtain.factory(
         {
@@ -155,7 +159,7 @@ define([
     );
 
     /**
-     * raises IOError if dir can't be created
+     * raises IOError if dir can't be created, or already exists
      */
     _p.mkDir = obtain.factory(
         {
@@ -167,7 +171,25 @@ define([
       , ['path']
       , function(obtain){ return obtain('mkDir'); }
     );
-    
+
+    /**
+     * raises IOError if dir can't be created.
+     *
+     * Note that you can't rely on the directory actually existing after a
+     * successful call: it may have been removed by the time you try to use
+     * it.
+     */
+    _p.ensureDir = obtain.factory(
+        {
+            ensureDir:['path', function(path) {
+                throw new NotImplementedError('ensureDir');
+            }]
+        }
+      , {/* no need for async here */}
+      , ['path']
+      , function(obtain){ return obtain('ensureDir'); }
+    );
+
     /**
      * raises IOError if dir can't be deleted
      */

--- a/lib/tools/io/staticBrowserREST.js
+++ b/lib/tools/io/staticBrowserREST.js
@@ -17,6 +17,7 @@ define([
     
     var IOError = errors.IO
       , IONoEntry = errors.IONoEntry
+      , IOEntryExists = errors.IOEntryExists
       ;
 
     function Io() {
@@ -25,8 +26,12 @@ define([
 
     var _p = Io.prototype = Object.create(Parent.prototype);
 
+    var _errorMessageFromRequest = function(request) {
+        return ['Status', request.status, request.statusText].join(' ');
+    }
+
     var _errorFromRequest = function(request) {
-        var message = ['Status', request.status, request.statusText].join(' ')
+        var message = _errorMessageFromRequest(request);
         if(request.status === 404)
             return new IONoEntry(message);
         //just don't use this if request.status == 200 or so is no error
@@ -240,15 +245,12 @@ define([
       , function(obtain){ return obtain('readBytes'); }
     );
 
-    // FIXME: the distinction between dir and file should be more
-    // robust :-/
-    // one problem for example is the io pathExists methods,
-    // which should work for files and directories regardless,
-    // but to work for directories it shoud attach a slash (so the REST
-    // server) can easily know what is meant
-    // PROPOSED FIX: the io api needs a split into: dirExists and fileExists
-    // so we could create a clear distinction and append the indicating
-    // slash. path exists would be removed
+    // FIXME: the pathExists method should work for both files and
+    // directories, but the REST server needs to know whether it's dealing
+    // with a file or directory, so we add a trailing slash in the latter
+    // case.
+    // 
+    // PROPOSED FIX: split pathExists into dirExists and fileExists.
     _p.pathExists = obtain.factory(
         {
             uri: ['path', _path2uri]
@@ -313,18 +315,18 @@ define([
     _p.mkDir = obtain.factory({
             uri: ['path', _path2uri]
           , dirName: ['uri', function(uri) {
-                // the endpoint will only create a directory if uri ends width
-                // a slash
+                // the endpoint will only create a directory if URI ends with /
                 return uri + (uri.slice(-1) !== '/' ? '/' : '');
             }]
           , mkDir:['dirName', function(path) {
                 var request = new XMLHttpRequest();
                 request.open('PUT', path, false);
                 request.send();
-                if (request.status !== 200 && request.status !== 201
+                if(request.status === 405)
+                    throw new IOEntryExists(message);
+                else if (request.status !== 200 && request.status !== 201
                         && request.status !== 204)
                     throw _errorFromRequest(request);
-                return;
             }]
         }
       , {
@@ -338,7 +340,9 @@ define([
                     if (request.readyState != 4 /*DONE*/)
                         return;
                     
-                    if (request.status !== 200 && request.status !== 201
+                    if (request.status === 405)
+                        error = new IOEntryExists(_errorMessageFromStatus(request));
+                    else if (request.status !== 200 && request.status !== 201
                             && request.status !== 204)
                         error = _errorFromRequest(request);
                     callback(error, result);
@@ -350,6 +354,31 @@ define([
       , function(obtain){ return obtain('mkDir'); }
     );
     
+    _p.ensureDir = obtain.factory({
+            ensureDir:['path', function(path) {
+                try {
+                    return this.mkDir(false, path);
+                } catch (err) {
+                    if (err instanceof IOEntryExists)
+                        return 0;
+                    throw err;
+                }
+            }]
+        }
+      , {
+            ensureDir:['path', '_callback', function(path, callback) {
+                var callbackSkipIoEntryExists = function(err, result) {
+                    if (err instanceof IOEntryExists)
+                        err = undefined;
+                    callback(err, result);
+                };
+                this.mkDir({callback: callbackSkipIoEntryExists}, path);
+            }]
+        }
+      , ['path']
+      , function(obtain){ return obtain('ensureDir'); }
+    );
+
     _p.rmDir = obtain.factory({
             uri: ['path', _path2uri]
           , dirName: ['uri', function(uri) {
@@ -363,7 +392,6 @@ define([
                 request.send();
                 if (request.status !== 200 && request.status !== 204)
                     throw _errorFromRequest(request);
-                return;
             }]
         }
       , {

--- a/lib/tools/io/staticNodeJS.js
+++ b/lib/tools/io/staticNodeJS.js
@@ -17,6 +17,7 @@ define([
 
     var IOError = errors.IO
       , IONoEntry = errors.IONoEntry
+      , IOEntryExists = errors.IOEntryExists
        // this is node js
       , fs = require.nodeRequire('fs')
       ;
@@ -27,11 +28,18 @@ define([
 
     var _p = Io.prototype = Object.create(Parent.prototype);
 
+    var _errorMap = {
+        'ENOENT': IONoEntry
+      , 'EEXIST': IOEntryExists
+    };
     var _errorFromIOError = function(error) {
-        if(error && error.code === 'ENOENT')
-            error = new IONoEntry(error.message, error.stack);
-        else if(error)
-            error = new IOError(error.code + ' ' + error.message, error.stack);
+        if(error) {
+            var cons = _errorMap[error.code];
+            if (cons)
+                error = new cons(error.message, error.stack);
+            else
+                error = new IOError(error.code + ' ' + error.message, error.stack);
+        }
         return error;
     }
 
@@ -236,9 +244,6 @@ define([
       , function(obtain){ return obtain('getMtime'); }
     );
 
-    /**
-     * raises IOError if dir can't be deleted
-     */
     _p.readDir = obtain.factory(
         {
             readDir:['path', fs.readdirSync]
@@ -253,9 +258,6 @@ define([
       , function(obtain){ return obtain('readDir'); }
     );
 
-    /**
-     * raises IOError if dir can't be created
-     */
     _p.mkDir = obtain.factory(
         {
             mkDir:['path', function(path) {
@@ -263,31 +265,48 @@ define([
                     return fs.mkdirSync(path)
                 }
                 catch(error) {
-                    if(error.code !== 'EEXIST')
-                        // skip if dir already existed
-                        throw new IOError(error.code + ' ' + error.message, error.stack);
+                    throw _errorFromIOError(error);
                 }
             }]
         }
       , {
             mkDir:['path', '_callback',
             function(path, callback) {
-                var callback = _callbackAdapterFactory(callback)
-                  , callbackSkipEEXIST = function(err) {
-                        if(err && error.code === 'EEXIST')
-                            err = undefined;
-                        callback(err)
-                    };
-                fs.mkdir(path, callbackSkipEEXIST)
+                fs.mkdir(path, _callbackAdapterFactory(callback));
             }]
         }
       , ['path']
       , function(obtain){ return obtain('mkDir'); }
     );
 
-    /**
-     * raises IOError if dir can't be deleted
-     */
+    _p.ensureDir = obtain.factory(
+        {
+            ensureDir:['path', function(path) {
+                try {
+                    return this.mkDir(false, path);
+                }
+                catch(error) {
+                    if(!(error instanceof IOEntryExists))
+                        throw error;
+                    return 0;
+                }
+            }]
+        }
+      , {
+            ensureDir:['path', '_callback',
+            function(path, callback) {
+                var callbackSkipIOEntryExists = function(err, result) {
+                        if(err instanceof IOEntryExists)
+                            err = undefined;
+                        callback(err, result)
+                    };
+                this.mkDir({callback: callbackSkipIoEntryExists}, path);
+            }]
+        }
+      , ['path']
+      , function(obtain){ return obtain('ensureDir'); }
+    );
+
     _p.rmDir = obtain.factory(
         {
             rmDir:['path', function(path) {


### PR DESCRIPTION
Add IOEntryExists for the case when an object exists already.

Improve the FIXME about the trailing slash issue for pathExists, and fix
some other comment typos.

Remove some specification comments in staticNodeJS.js which duplicate
those in _base.js.

Add a warning about misuse of pathExists to _base.js.
