### PR TITLE
Rewrite staticBrowserREST.js

### DIFF
--- a/lib/tools/io/staticBrowserREST.js
+++ b/lib/tools/io/staticBrowserREST.js
@@ -52,7 +52,7 @@ define([
     // We signal a directory to the REST endpoint by adding a / suffix
     var _dirify = function (f) {
         return function (async, path, data) {
-            return f(async, function(path) { return uri + (uri.slice(-1) !== '/' ? '/' : ''); }, data);
+            return f(async, path + (path.slice(-1) !== '/' ? '/' : ''), data);
         }
     };
 
@@ -132,7 +132,12 @@ define([
     });
 
     _p.fileExists = _obtainRequestFactory('HEAD', undefined, undefined, function (error, result) {
-        return [error instanceof IONoEntry ? false : error, result];
+        result = true;
+        if (error instanceof IONoEntry) {
+            result = false;
+            error = undefined;
+        }
+        return [error, result];
     });
     _p.dirExists = _dirify(_p.fileExists);       
     _p.pathExists = _p.fileExists; // DEPRECATED: use dirExists or fileExists
@@ -155,7 +160,7 @@ define([
         return [error, result];
     }));
 
-    _p.ensureDir = _dirify(_obtainRequestFactory('PUT', undefined, {200: true, 201: true, 204: true}));
+    _p.ensureDir = _dirify(_obtainRequestFactory('PUT', undefined, {200: true, 201: true, 204: true, 405: true}));
 
     _p.rmDir = _dirify(_p.unlink);
 


### PR DESCRIPTION
This rewrite is in two parts. The first can be accepted without the
second.
1. Factor out the request logic into two functions. This gives
   considerable simplification.
2. However, once this simplification has been achieved, it seems that
   using obtainJS is overkill for this module, so the second part removes
   it, reducing the size of the module considerably.
