### PR TITLE
FIX: rmDirRecursive lost its binding to `this` when in deeper recursion ...

### DIFF
--- a/lib/tools/io/_base.js
+++ b/lib/tools/io/_base.js
@@ -217,7 +217,8 @@ define([
                 var objs = this.readDir(false, dir);
                 for(var i = 0; i < objs.length; i++) {
                     var obj = dir + '/' + objs[i]; // path.join is node-specific
-                    (this.stat(false, obj).isDirectory() ? this.rmDirRecursive : this.unlink)(false, obj);
+                    this[this.stat(false, obj).isDirectory()
+                            ? 'rmDirRecursive' : 'unlink'](false, obj);
                 }
                 this.rmDir(false, dir);
             }]


### PR DESCRIPTION
...depths

found by @felipesanches

Cause was a noteworthy javascript syntax fauxpas where essentially in the call
(true ? this.myMethod : this:otherMethod)() the conditional would return the bare
method without a binding to `this` in the subsequent call :-)